### PR TITLE
Fixed to save manifestation when import from SRU response.

### DIFF
--- a/app/models/ndl_book.rb
+++ b/app/models/ndl_book.rb
@@ -37,7 +37,8 @@ class NdlBook
     manifestation = Manifestation.where(:nbn => jpno).first
     return if manifestation
     url = "http://iss.ndl.go.jp/api/sru?operation=searchRetrieve&recordSchema=dcndl&&maximumRecords=1&&query=%28jpno=#{jpno}%29"
-    response = Nokogiri::XML(open("http://iss.ndl.go.jp/api/sru?operation=searchRetrieve&recordSchema=dcndl&&maximumRecords=1&&query=%28jpno=#{jpno}%29")).at('//xmlns:recordData')
+    xml = open(url).read
+    response = Nokogiri::XML(xml).at('//xmlns:recordData')
     return unless response.content
     doc = Nokogiri::XML(response.content)
     Manifestation.import_record(doc)

--- a/lib/enju_ndl/ndl_search.rb
+++ b/lib/enju_ndl/ndl_search.rb
@@ -67,6 +67,7 @@ module EnjuNdl
         end
 
         #manifestation.send_later(:create_frbr_instance, doc.to_s)
+        manifestation.save!
         return manifestation
       end
 


### PR DESCRIPTION
I tried to wrote patch to save manifestation when import from SRU search result. You can still reproduce with online demo sites ( Acquisition -> Import from NDL search -> (some query) -> add, and cause routing error ) . 

BTW, current stable version of Enju-leaf points enju_ndl version >=0.0.4 on Gemfile which uses  obsolete PORTA query. It seems must publish newer verion ( 0.0.5? ) of enju_ndl to rubygems.org for stable version.
