### PR TITLE
nabeta/enju_leaf#61 で発生したバグを修正し、NdlBooks をリファクタリング

### DIFF
--- a/app/models/ndl_book.rb
+++ b/app/models/ndl_book.rb
@@ -11,11 +11,19 @@ class NdlBook
   end
 
   def permalink
-    @node.at('./link').content
+    @node.at('./link').try(:content).to_s
   end
 
   def title
-    "#{@node.at('./title').content} #{@node.at('./dcndl:volume').content}"
+    @node.at('./title').try(:content).to_s
+  end
+
+  def volume
+    @node.at('./dcndl:volume').try(:content).to_s
+  end
+
+  def series_title
+    @node.at('./dcndl:seriesTitle').try(:content).to_s
   end
 
   def creator
@@ -27,7 +35,7 @@ class NdlBook
   end
 
   def issued
-    @node.at('./dcterms:issued[@xsi:type="dcterms:W3CDTF"]').try(:content)
+    @node.at('./dcterms:issued[@xsi:type="dcterms:W3CDTF"]').try(:content).to_s
   end
 
   def isbn

--- a/app/views/ndl_books/index.html.erb
+++ b/app/views/ndl_books/index.html.erb
@@ -24,7 +24,7 @@
         <%= link_to_import(book.jpno) %>
       </td>
       <td>
-        <%= link_to book.title , book.permalink %>
+        <%= link_to "#{book.title} #{book.volume}".strip , book.permalink %>
         <br />
         <%= book.creator %>
       	<%= book.publisher %>

--- a/spec/cassette_library/enju_ndl/import.yml
+++ b/spec/cassette_library/enju_ndl/import.yml
@@ -5114,4 +5114,365 @@ http_interactions:
     http_version: !binary |-
       MS4w
   recorded_at: Sat, 13 Oct 2012 06:36:07 GMT
+- request:
+    method: get
+    uri: http://iss.ndl.go.jp/api/opensearch?dpid=iss-ndl-opac&any=978-4-04-874013-5&cnt=10&idx=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - ! '*/*'
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: !binary |-
+        T0s=
+    headers:
+      !binary "ZGF0ZQ==":
+      - !binary |-
+        U2F0LCAxMyBPY3QgMjAxMiAwNzo1MDowNyBHTVQ=
+      !binary "c2VydmVy":
+      - !binary |-
+        QXBhY2hl
+      !binary "eC1wb3dlcmVkLWJ5":
+      - !binary |-
+        UGh1c2lvbiBQYXNzZW5nZXIgKG1vZF9yYWlscy9tb2RfcmFjaykgMi4yLjE1
+      !binary "ZXRhZw==":
+      - !binary |-
+        IjdlNTBmZTIxYTc4N2NiNGQ2MjkzNzA1OTU4ODVhYTUzIg==
+      !binary "eC11YS1jb21wYXRpYmxl":
+      - !binary |-
+        SUU9RWRnZSxjaHJvbWU9MQ==
+      !binary "eC1ydW50aW1l":
+      - !binary |-
+        MC4xNzE1ODM=
+      !binary "Y2FjaGUtY29udHJvbA==":
+      - !binary |-
+        bWF4LWFnZT0wLCBwcml2YXRlLCBtdXN0LXJldmFsaWRhdGU=
+      !binary "Y29udGVudC1sZW5ndGg=":
+      - !binary |-
+        MjE1MQ==
+      !binary "c3RhdHVz":
+      - !binary |-
+        MjAw
+      !binary "Y29udGVudC10eXBl":
+      - !binary |-
+        YXBwbGljYXRpb24veG1sOyBjaGFyc2V0PXV0Zi04
+      !binary "c2V0LWNvb2tpZQ==":
+      - !binary |-
+        X2Zyb250X3Nlc3Npb25faWQ9NDc5NzQxZmY4MmI0YTQ5YWQxZjQyYjU5Yzk1
+        MDFlZjU7IGRvbWFpbj0uaXNzLm5kbC5nby5qcDsgcGF0aD0vOyBleHBpcmVz
+        PVNhdCwgMTMtT2N0LTIwMTIgMDg6NTA6MDcgR01UOyBIdHRwT25seQ==
+      - !binary |-
+        c2VydmVyaWQ9MTEwMTsgcGF0aD0v
+      !binary "dmFyeQ==":
+      - !binary |-
+        QWNjZXB0LUVuY29kaW5nLFVzZXItQWdlbnQ=
+      !binary "Y29ubmVjdGlvbg==":
+      - !binary |-
+        Y2xvc2U=
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJzcyB4
+        bWxuczpkY3Rlcm1zPSJodHRwOi8vcHVybC5vcmcvZGMvdGVybXMvIiB4bWxu
+        czpkY25kbD0iaHR0cDovL25kbC5nby5qcC9kY25kbC90ZXJtcy8iIHZlcnNp
+        b249IjIuMCIgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50
+        cy8xLjEvIiB4bWxuczpvcGVuU2VhcmNoPSJodHRwOi8vYTkuY29tLy0vc3Bl
+        Yy9vcGVuc2VhcmNocnNzLzEuMC8iIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53
+        My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zOmRjbWl0eXBl
+        PSJodHRwOi8vcHVybC5vcmcvZGMvZGNtaXR5cGUvIj4KICA8Y2hhbm5lbD4K
+        ICAgIDx0aXRsZT45NzgtNC0wNC04NzQwMTMtNSBpc3MtbmRsLW9wYWMgLSDl
+        m73nq4vlm73kvJrlm7Pmm7jppKjjgrXjg7zjg4EgT3BlblNlYXJjaDwvdGl0
+        bGU+CiAgICA8bGluaz5pc3MubmRsLmdvLmpwPC9saW5rPgogICAgPGRlc2Ny
+        aXB0aW9uPlNlYXJjaCByZXN1bHRzIGZvciBhbnk9OTc4LTQtMDQtODc0MDEz
+        LTUgY250PTEwIGRwaWQ9aXNzLW5kbC1vcGFjIDwvZGVzY3JpcHRpb24+CiAg
+        ICA8bGFuZ3VhZ2U+amE8L2xhbmd1YWdlPgogICAgPG9wZW5TZWFyY2g6dG90
+        YWxSZXN1bHRzPjE8L29wZW5TZWFyY2g6dG90YWxSZXN1bHRzPgogICAgPG9w
+        ZW5TZWFyY2g6c3RhcnRJbmRleD4xPC9vcGVuU2VhcmNoOnN0YXJ0SW5kZXg+
+        CiAgICA8b3BlblNlYXJjaDppdGVtc1BlclBhZ2U+MTA8L29wZW5TZWFyY2g6
+        aXRlbXNQZXJQYWdlPgogICAgPGl0ZW0+CiAgICAgIDx0aXRsZT7lpKnlnLDm
+        mI7lr588L3RpdGxlPgogICAgICA8bGluaz5odHRwOi8vaXNzLm5kbC5nby5q
+        cC9ib29rcy9SMTAwMDAwMDAyLUkwMDAwMTA2MzYwMTUtMDA8L2xpbms+Cjxk
+        ZXNjcmlwdGlvbj4KPCFbQ0RBVEFbPHA+6KeS5bed5pu45bqXLDk3ODQwNDg3
+        NDAxMzU8L3A+Cjx1bD48bGk+44K/44Kk44OI44Or77yaIOWkqeWcsOaYjuWv
+        nzwvbGk+CjxsaT7jgr/jgqTjg4jjg6vvvIjoqq3jgb/vvInvvJog44OG44Oz
+        44OBIOODoeOCpOOCteODhDwvbGk+CjxsaT7osqzku7vooajnpLrvvJog5Yay
+        5pa55LiBIOiRlyw8L2xpPgo8bGk+TkRDKDkp77yaIDkxMy42PC9saT4KPC91
+        bD5dXT4KPC9kZXNjcmlwdGlvbj4KICAgICAgPGF1dGhvcj7lhrLmlrnkuIEg
+        6JGXLDwvYXV0aG9yPgogICAgICA8Y2F0ZWdvcnk+5pysPC9jYXRlZ29yeT4K
+        ICAgICAgPGd1aWQgaXNQZXJtYUxpbms9InRydWUiPmh0dHA6Ly9pc3MubmRs
+        LmdvLmpwL2Jvb2tzL1IxMDAwMDAwMDItSTAwMDAxMDYzNjAxNS0wMDwvZ3Vp
+        ZD4KICAgICAgPHB1YkRhdGU+VGh1LCAwNyBKYW4gMjAxMCAwOTowMDowMCAr
+        MDkwMDwvcHViRGF0ZT4KICAgICAgPGRjOnRpdGxlPuWkqeWcsOaYjuWvnzwv
+        ZGM6dGl0bGU+CiAgICAgIDxkY25kbDp0aXRsZVRyYW5zY3JpcHRpb24+44OG
+        44Oz44OBIOODoeOCpOOCteODhDwvZGNuZGw6dGl0bGVUcmFuc2NyaXB0aW9u
+        PgogICAgICA8ZGM6Y3JlYXRvcj7lhrLmlrnkuIEg6JGXPC9kYzpjcmVhdG9y
+        PgogICAgICA8ZGM6cHVibGlzaGVyPuinkuW3neabuOW6lzwvZGM6cHVibGlz
+        aGVyPgogICAgICA8ZGM6cHVibGlzaGVyPuinkuW3neOCsOODq+ODvOODl+OD
+        keODluODquODg+OCt+ODs+OCsDwvZGM6cHVibGlzaGVyPgogICAgICA8ZGN0
+        ZXJtczppc3N1ZWQgeHNpOnR5cGU9ImRjdGVybXM6VzNDRFRGIj4yMDA5PC9k
+        Y3Rlcm1zOmlzc3VlZD4KICAgICAgPGRjOmlkZW50aWZpZXIgeHNpOnR5cGU9
+        ImRjbmRsOklTQk4iPjk3ODQwNDg3NDAxMzU8L2RjOmlkZW50aWZpZXI+CiAg
+        ICAgIDxkYzppZGVudGlmaWVyIHhzaTp0eXBlPSJkY25kbDpKUE5PIj4yMTY4
+        OTY3MzwvZGM6aWRlbnRpZmllcj4KICAgICAgPGRjOmlkZW50aWZpZXIgeHNp
+        OnR5cGU9ImRjbmRsOk5TTUFSQ05PIj4xMDQzMjQ4MDA8L2RjOmlkZW50aWZp
+        ZXI+CiAgICAgIDxkYzpzdWJqZWN0IHhzaTp0eXBlPSJkY25kbDpORExDIj5L
+        SDY0NDwvZGM6c3ViamVjdD4KICAgICAgPGRjOnN1YmplY3QgeHNpOnR5cGU9
+        ImRjbmRsOk5EQzkiPjkxMy42PC9kYzpzdWJqZWN0PgogICAgICA8ZGN0ZXJt
+        czpkZXNjcmlwdGlvbj7mlofnjK7jgYLjgoo8L2RjdGVybXM6ZGVzY3JpcHRp
+        b24+CiAgICA8L2l0ZW0+CiAgPC9jaGFubmVsPgo8L3Jzcz4K
+    http_version: !binary |-
+      MS4w
+  recorded_at: Sat, 13 Oct 2012 07:50:07 GMT
+- request:
+    method: get
+    uri: http://iss.ndl.go.jp/api/opensearch?dpid=iss-ndl-opac&any=4840114404&cnt=10&idx=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - ! '*/*'
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: !binary |-
+        T0s=
+    headers:
+      !binary "ZGF0ZQ==":
+      - !binary |-
+        U2F0LCAxMyBPY3QgMjAxMiAwODoyMToxNiBHTVQ=
+      !binary "c2VydmVy":
+      - !binary |-
+        QXBhY2hl
+      !binary "eC1wb3dlcmVkLWJ5":
+      - !binary |-
+        UGh1c2lvbiBQYXNzZW5nZXIgKG1vZF9yYWlscy9tb2RfcmFjaykgMi4yLjE1
+      !binary "ZXRhZw==":
+      - !binary |-
+        ImI4YTUwMzRjNDlhMjcyNTcxZDQ4ODAyMmFmYmRlMDY5Ig==
+      !binary "eC11YS1jb21wYXRpYmxl":
+      - !binary |-
+        SUU9RWRnZSxjaHJvbWU9MQ==
+      !binary "eC1ydW50aW1l":
+      - !binary |-
+        MC4yMDc4Nzg=
+      !binary "Y2FjaGUtY29udHJvbA==":
+      - !binary |-
+        bWF4LWFnZT0wLCBwcml2YXRlLCBtdXN0LXJldmFsaWRhdGU=
+      !binary "Y29udGVudC1sZW5ndGg=":
+      - !binary |-
+        MjQ1NA==
+      !binary "c3RhdHVz":
+      - !binary |-
+        MjAw
+      !binary "Y29udGVudC10eXBl":
+      - !binary |-
+        YXBwbGljYXRpb24veG1sOyBjaGFyc2V0PXV0Zi04
+      !binary "c2V0LWNvb2tpZQ==":
+      - !binary |-
+        X2Zyb250X3Nlc3Npb25faWQ9YTlhNjNlNTM1M2JhNjlmMzBlZGMzNzhjNDRj
+        ODM2Mjk7IGRvbWFpbj0uaXNzLm5kbC5nby5qcDsgcGF0aD0vOyBleHBpcmVz
+        PVNhdCwgMTMtT2N0LTIwMTIgMDk6MjE6MTYgR01UOyBIdHRwT25seQ==
+      - !binary |-
+        c2VydmVyaWQ9MTEwMTsgcGF0aD0v
+      !binary "dmFyeQ==":
+      - !binary |-
+        QWNjZXB0LUVuY29kaW5nLFVzZXItQWdlbnQ=
+      !binary "Y29ubmVjdGlvbg==":
+      - !binary |-
+        Y2xvc2U=
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJzcyB4
+        bWxuczpkY3Rlcm1zPSJodHRwOi8vcHVybC5vcmcvZGMvdGVybXMvIiB4bWxu
+        czpkY25kbD0iaHR0cDovL25kbC5nby5qcC9kY25kbC90ZXJtcy8iIHZlcnNp
+        b249IjIuMCIgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50
+        cy8xLjEvIiB4bWxuczpvcGVuU2VhcmNoPSJodHRwOi8vYTkuY29tLy0vc3Bl
+        Yy9vcGVuc2VhcmNocnNzLzEuMC8iIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53
+        My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zOmRjbWl0eXBl
+        PSJodHRwOi8vcHVybC5vcmcvZGMvZGNtaXR5cGUvIj4KICA8Y2hhbm5lbD4K
+        ICAgIDx0aXRsZT40ODQwMTE0NDA0IGlzcy1uZGwtb3BhYyAtIOWbveeri+Wb
+        veS8muWbs+abuOmkqOOCteODvOODgSBPcGVuU2VhcmNoPC90aXRsZT4KICAg
+        IDxsaW5rPmlzcy5uZGwuZ28uanA8L2xpbms+CiAgICA8ZGVzY3JpcHRpb24+
+        U2VhcmNoIHJlc3VsdHMgZm9yIGFueT00ODQwMTE0NDA0IGNudD0xMCBkcGlk
+        PWlzcy1uZGwtb3BhYyA8L2Rlc2NyaXB0aW9uPgogICAgPGxhbmd1YWdlPmph
+        PC9sYW5ndWFnZT4KICAgIDxvcGVuU2VhcmNoOnRvdGFsUmVzdWx0cz4xPC9v
+        cGVuU2VhcmNoOnRvdGFsUmVzdWx0cz4KICAgIDxvcGVuU2VhcmNoOnN0YXJ0
+        SW5kZXg+MTwvb3BlblNlYXJjaDpzdGFydEluZGV4PgogICAgPG9wZW5TZWFy
+        Y2g6aXRlbXNQZXJQYWdlPjEwPC9vcGVuU2VhcmNoOml0ZW1zUGVyUGFnZT4K
+        ICAgIDxpdGVtPgogICAgICA8dGl0bGU+44OJ44Op44K044Oz44Go6a2U5rOV
+        44Gu5rC0PC90aXRsZT4KICAgICAgPGxpbms+aHR0cDovL2lzcy5uZGwuZ28u
+        anAvYm9va3MvUjEwMDAwMDAwMi1JMDAwMDA4MTgwMDAzLTAwPC9saW5rPgo8
+        ZGVzY3JpcHRpb24+CjwhW0NEQVRBWzxwPuODoeODh+OCo+OCouODleOCoeOC
+        r+ODiOODquODvCw0ODQwMTE0NDA0PC9wPgo8dWw+PGxpPuOCv+OCpOODiOOD
+        q++8miDjg4njg6njgrTjg7PjgajprZTms5Xjga7msLQ8L2xpPgo8bGk+44K/
+        44Kk44OI44Or77yI6Kqt44G/77yJ77yaIOODieODqeOCtOODsyDjg4gg44Oe
+        44Ob44KmIOODjiDjg5/jgro8L2xpPgo8bGk+6LKs5Lu76KGo56S677yaIOOD
+        oeOCouODquODvOODu+ODneODvOODl+ODu+OCquOCuuODnOODvOODsyDokZcs
+        6aOf6YeO6ZuF5a2QIOiosyw8L2xpPgo8bGk+44K344Oq44O844K65ZCN77ya
+        IOODnuOCuOODg+OCr+ODu+ODhOODquODvOODj+OCpuOCuSA7IDE1PC9saT4K
+        PGxpPk5EQyg5Ke+8miA5MzMuNzwvbGk+CjwvdWw+XV0+CjwvZGVzY3JpcHRp
+        b24+CiAgICAgIDxhdXRob3I+44Oh44Ki44Oq44O844O744Od44O844OX44O7
+        44Kq44K644Oc44O844OzIOiRlyzpo5/ph47pm4XlrZAg6KizLDwvYXV0aG9y
+        PgogICAgICA8Y2F0ZWdvcnk+5YWQ56ul5pu4PC9jYXRlZ29yeT4KICAgICAg
+        PGd1aWQgaXNQZXJtYUxpbms9InRydWUiPmh0dHA6Ly9pc3MubmRsLmdvLmpw
+        L2Jvb2tzL1IxMDAwMDAwMDItSTAwMDAwODE4MDAwMy0wMDwvZ3VpZD4KICAg
+        ICAgPHB1YkRhdGU+V2VkLCAwNyBKdW4gMjAwNiAwOTowMDowMCArMDkwMDwv
+        cHViRGF0ZT4KICAgICAgPGRjOnRpdGxlPuODieODqeOCtOODs+OBqOmtlOaz
+        leOBruawtDwvZGM6dGl0bGU+CiAgICAgIDxkY25kbDp0aXRsZVRyYW5zY3Jp
+        cHRpb24+44OJ44Op44K044OzIOODiCDjg57jg5vjgqYg44OOIOODn+OCujwv
+        ZGNuZGw6dGl0bGVUcmFuc2NyaXB0aW9uPgogICAgICA8ZGM6Y3JlYXRvcj7j
+        g6HjgqLjg6rjg7zjg7vjg53jg7zjg5fjg7vjgqrjgrrjg5zjg7zjg7Mg6JGX
+        PC9kYzpjcmVhdG9yPgogICAgICA8ZGM6Y3JlYXRvcj7po5/ph47pm4XlrZAg
+        6KizPC9kYzpjcmVhdG9yPgogICAgICA8ZGNuZGw6c2VyaWVzVGl0bGU+44Oe
+        44K444OD44Kv44O744OE44Oq44O844OP44Km44K5IDsgMTU8L2RjbmRsOnNl
+        cmllc1RpdGxlPgogICAgICA8ZGM6cHVibGlzaGVyPuODoeODh+OCo+OCouOD
+        leOCoeOCr+ODiOODquODvDwvZGM6cHVibGlzaGVyPgogICAgICA8ZGN0ZXJt
+        czppc3N1ZWQgeHNpOnR5cGU9ImRjdGVybXM6VzNDRFRGIj4yMDA1PC9kY3Rl
+        cm1zOmlzc3VlZD4KICAgICAgPGRjOmlkZW50aWZpZXIgeHNpOnR5cGU9ImRj
+        bmRsOklTQk4iPjQ4NDAxMTQ0MDQ8L2RjOmlkZW50aWZpZXI+CiAgICAgIDxk
+        YzppZGVudGlmaWVyIHhzaTp0eXBlPSJkY25kbDpKUE5PIj4yMTAyNzUyNTwv
+        ZGM6aWRlbnRpZmllcj4KICAgICAgPGRjOnN1YmplY3QgeHNpOnR5cGU9ImRj
+        bmRsOk5ETEMiPlk3PC9kYzpzdWJqZWN0PgogICAgICA8ZGM6c3ViamVjdCB4
+        c2k6dHlwZT0iZGNuZGw6TkRDOSI+OTMzLjc8L2RjOnN1YmplY3Q+CiAgICAg
+        IDxkY3Rlcm1zOmRlc2NyaXB0aW9uPuWOn+OCv+OCpOODiOODqzogQ2hyaXN0
+        bWFzIGluIENhbWVsb3Q8L2RjdGVybXM6ZGVzY3JpcHRpb24+CiAgICA8L2l0
+        ZW0+CiAgPC9jaGFubmVsPgo8L3Jzcz4K
+    http_version: !binary |-
+      MS4w
+  recorded_at: Sat, 13 Oct 2012 08:21:16 GMT
+- request:
+    method: get
+    uri: http://iss.ndl.go.jp/api/opensearch?dpid=iss-ndl-opac&any=4788509105&cnt=10&idx=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - ! '*/*'
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: !binary |-
+        T0s=
+    headers:
+      !binary "ZGF0ZQ==":
+      - !binary |-
+        U2F0LCAxMyBPY3QgMjAxMiAwODoyMToxNiBHTVQ=
+      !binary "c2VydmVy":
+      - !binary |-
+        QXBhY2hl
+      !binary "eC1wb3dlcmVkLWJ5":
+      - !binary |-
+        UGh1c2lvbiBQYXNzZW5nZXIgKG1vZF9yYWlscy9tb2RfcmFjaykgMi4yLjE1
+      !binary "ZXRhZw==":
+      - !binary |-
+        ImFlOGZkMWRmOWQ2NDczNDA4ZDgyOGExMTVkODhiOGZhIg==
+      !binary "eC11YS1jb21wYXRpYmxl":
+      - !binary |-
+        SUU9RWRnZSxjaHJvbWU9MQ==
+      !binary "eC1ydW50aW1l":
+      - !binary |-
+        MC4yMTExNTc=
+      !binary "Y2FjaGUtY29udHJvbA==":
+      - !binary |-
+        bWF4LWFnZT0wLCBwcml2YXRlLCBtdXN0LXJldmFsaWRhdGU=
+      !binary "Y29udGVudC1sZW5ndGg=":
+      - !binary |-
+        MjY1OQ==
+      !binary "c3RhdHVz":
+      - !binary |-
+        MjAw
+      !binary "Y29udGVudC10eXBl":
+      - !binary |-
+        YXBwbGljYXRpb24veG1sOyBjaGFyc2V0PXV0Zi04
+      !binary "c2V0LWNvb2tpZQ==":
+      - !binary |-
+        X2Zyb250X3Nlc3Npb25faWQ9YWFlZmRkNmQ1ODg1N2EzMWI0YzAzMjkwMDBi
+        NTgzMTc7IGRvbWFpbj0uaXNzLm5kbC5nby5qcDsgcGF0aD0vOyBleHBpcmVz
+        PVNhdCwgMTMtT2N0LTIwMTIgMDk6MjE6MTYgR01UOyBIdHRwT25seQ==
+      - !binary |-
+        c2VydmVyaWQ9MTEwNTsgcGF0aD0v
+      !binary "dmFyeQ==":
+      - !binary |-
+        QWNjZXB0LUVuY29kaW5nLFVzZXItQWdlbnQ=
+      !binary "Y29ubmVjdGlvbg==":
+      - !binary |-
+        Y2xvc2U=
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJzcyB4
+        bWxuczpkY3Rlcm1zPSJodHRwOi8vcHVybC5vcmcvZGMvdGVybXMvIiB4bWxu
+        czpkY25kbD0iaHR0cDovL25kbC5nby5qcC9kY25kbC90ZXJtcy8iIHZlcnNp
+        b249IjIuMCIgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50
+        cy8xLjEvIiB4bWxuczpvcGVuU2VhcmNoPSJodHRwOi8vYTkuY29tLy0vc3Bl
+        Yy9vcGVuc2VhcmNocnNzLzEuMC8iIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53
+        My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zOmRjbWl0eXBl
+        PSJodHRwOi8vcHVybC5vcmcvZGMvZGNtaXR5cGUvIj4KICA8Y2hhbm5lbD4K
+        ICAgIDx0aXRsZT40Nzg4NTA5MTA1IGlzcy1uZGwtb3BhYyAtIOWbveeri+Wb
+        veS8muWbs+abuOmkqOOCteODvOODgSBPcGVuU2VhcmNoPC90aXRsZT4KICAg
+        IDxsaW5rPmlzcy5uZGwuZ28uanA8L2xpbms+CiAgICA8ZGVzY3JpcHRpb24+
+        U2VhcmNoIHJlc3VsdHMgZm9yIGFueT00Nzg4NTA5MTA1IGNudD0xMCBkcGlk
+        PWlzcy1uZGwtb3BhYyA8L2Rlc2NyaXB0aW9uPgogICAgPGxhbmd1YWdlPmph
+        PC9sYW5ndWFnZT4KICAgIDxvcGVuU2VhcmNoOnRvdGFsUmVzdWx0cz4xPC9v
+        cGVuU2VhcmNoOnRvdGFsUmVzdWx0cz4KICAgIDxvcGVuU2VhcmNoOnN0YXJ0
+        SW5kZXg+MTwvb3BlblNlYXJjaDpzdGFydEluZGV4PgogICAgPG9wZW5TZWFy
+        Y2g6aXRlbXNQZXJQYWdlPjEwPC9vcGVuU2VhcmNoOml0ZW1zUGVyUGFnZT4K
+        ICAgIDxpdGVtPgogICAgICA8dGl0bGU+55+l6K2Y44Gu56S+5Lya5Y+yIDog
+        55+l44Go5oOF5aCx44Gv44GE44GL44Gr44GX44Gm5ZWG5ZOB5YyW44GX44Gf
+        44GLPC90aXRsZT4KICAgICAgPGxpbms+aHR0cDovL2lzcy5uZGwuZ28uanAv
+        Ym9va3MvUjEwMDAwMDAwMi1JMDAwMDA3NDU2NTg0LTAwPC9saW5rPgo8ZGVz
+        Y3JpcHRpb24+CjwhW0NEQVRBWzxwPuaWsOabnOekviw0Nzg4NTA5MTA1PC9w
+        Pgo8dWw+PGxpPuOCv+OCpOODiOODq++8miDnn6XorZjjga7npL7kvJrlj7Ig
+        OiDnn6Xjgajmg4XloLHjga/jgYTjgYvjgavjgZfjgabllYblk4HljJbjgZfj
+        gZ/jgYs8L2xpPgo8bGk+44K/44Kk44OI44Or77yI6Kqt44G/77yJ77yaIOOD
+        geOCt+OCrSDjg44g44K344Oj44Kr44Kk44K3IDog44OBIOODiCDjgrjjg6fj
+        gqbjg5vjgqYg44OvIOOCpOOCq+ODi+OCt+ODhiDjgrfjg6fjgqbjg5Ljg7Pj
+        gqvjgrfjgr/jgqs8L2xpPgo8bGk+6LKs5Lu76KGo56S677yaIOODlOODvOOC
+        v+ODvOODu+ODkOODvOOCryDokZcs5LqV5bGx5byY5bm4LCDln47miLjmt7Mg
+        6KizLDwvbGk+CjxsaT5OREMoOSnvvJogMzYxLjU8L2xpPgo8L3VsPl1dPgo8
+        L2Rlc2NyaXB0aW9uPgogICAgICA8YXV0aG9yPuODlOODvOOCv+ODvOODu+OD
+        kOODvOOCryDokZcs5LqV5bGx5byY5bm4LCDln47miLjmt7Mg6KizLDwvYXV0
+        aG9yPgogICAgICA8Y2F0ZWdvcnk+5pysPC9jYXRlZ29yeT4KICAgICAgPGd1
+        aWQgaXNQZXJtYUxpbms9InRydWUiPmh0dHA6Ly9pc3MubmRsLmdvLmpwL2Jv
+        b2tzL1IxMDAwMDAwMDItSTAwMDAwNzQ1NjU4NC0wMDwvZ3VpZD4KICAgICAg
+        PHB1YkRhdGU+RnJpLCAwOCBPY3QgMjAwNCAwOTowMDowMCArMDkwMDwvcHVi
+        RGF0ZT4KICAgICAgPGRjOnRpdGxlPuefpeitmOOBruekvuS8muWPsiA6IOef
+        peOBqOaDheWgseOBr+OBhOOBi+OBq+OBl+OBpuWVhuWTgeWMluOBl+OBn+OB
+        izwvZGM6dGl0bGU+CiAgICAgIDxkY25kbDp0aXRsZVRyYW5zY3JpcHRpb24+
+        44OB44K344KtIOODjiDjgrfjg6PjgqvjgqTjgrcgOiDjg4Eg44OIIOOCuOOD
+        p+OCpuODm+OCpiDjg68g44Kk44Kr44OL44K344OGIOOCt+ODp+OCpuODkuOD
+        s+OCq+OCt+OCv+OCqzwvZGNuZGw6dGl0bGVUcmFuc2NyaXB0aW9uPgogICAg
+        ICA8ZGM6Y3JlYXRvcj7jg5Tjg7zjgr/jg7zjg7vjg5Djg7zjgq8g6JGXPC9k
+        YzpjcmVhdG9yPgogICAgICA8ZGM6Y3JlYXRvcj7kupXlsbHlvJjlubgsIOWf
+        juaIuOa3syDoqLM8L2RjOmNyZWF0b3I+CiAgICAgIDxkYzpwdWJsaXNoZXI+
+        5paw5puc56S+PC9kYzpwdWJsaXNoZXI+CiAgICAgIDxkY3Rlcm1zOmlzc3Vl
+        ZCB4c2k6dHlwZT0iZGN0ZXJtczpXM0NEVEYiPjIwMDQ8L2RjdGVybXM6aXNz
+        dWVkPgogICAgICA8ZGM6aWRlbnRpZmllciB4c2k6dHlwZT0iZGNuZGw6SVNC
+        TiI+NDc4ODUwOTEwNTwvZGM6aWRlbnRpZmllcj4KICAgICAgPGRjOmlkZW50
+        aWZpZXIgeHNpOnR5cGU9ImRjbmRsOkpQTk8iPjIwNjY0MTUyPC9kYzppZGVu
+        dGlmaWVyPgogICAgICA8ZGM6c3ViamVjdD7nn6XorZjnpL7kvJrlraY8L2Rj
+        OnN1YmplY3Q+CiAgICAgIDxkYzpzdWJqZWN0PuWtpuihky0t5q205Y+yPC9k
+        YzpzdWJqZWN0PgogICAgICA8ZGM6c3ViamVjdCB4c2k6dHlwZT0iZGNuZGw6
+        TkRMQyI+RUMyMTE8L2RjOnN1YmplY3Q+CiAgICAgIDxkYzpzdWJqZWN0IHhz
+        aTp0eXBlPSJkY25kbDpOREM5Ij4zNjEuNTwvZGM6c3ViamVjdD4KICAgICAg
+        PGRjdGVybXM6ZGVzY3JpcHRpb24+5Y6f44K/44Kk44OI44OrOiBBIHNvY2lh
+        bCBoaXN0b3J5IG9mIGtub3dsZWRnZTwvZGN0ZXJtczpkZXNjcmlwdGlvbj4K
+        ICAgICAgPGRjdGVybXM6ZGVzY3JpcHRpb24+5paH54yu44GC44KKPC9kY3Rl
+        cm1zOmRlc2NyaXB0aW9uPgogICAgPC9pdGVtPgogIDwvY2hhbm5lbD4KPC9y
+        c3M+Cg==
+    http_version: !binary |-
+      MS4w
+  recorded_at: Sat, 13 Oct 2012 08:21:16 GMT
 recorded_with: VCR 2.2.5

--- a/spec/models/ndl_book_spec.rb
+++ b/spec/models/ndl_book_spec.rb
@@ -92,7 +92,23 @@ describe NdlBook do
     end
 
     it "should get volume number" do
-      NdlBook.search('978-4-04-100292-6')[:items].first.title.should eq "天地明察 下"
+      NdlBook.search('978-4-04-100292-6')[:items].first.volume.should eq "下"
     end
+
+    it "should not get volume number if book has not volume" do
+      NdlBook.search('978-4-04-874013-5')[:items].first.volume.should eq ""
+    end
+
+    it "should get series title" do
+      book = NdlBook.search("4840114404")[:items].first
+      book.series_title.should eq "マジック・ツリーハウス ; 15"
+    end
+
+    it "should not get series title if book has not series title" do
+      book = NdlBook.search("4788509105")[:items].first
+      book.series_title.should eq ""
+    end
+   
+
   end
 end


### PR DESCRIPTION
巻次の無い本のタイトルを取得する場合にエラーが起こるバグを修正しました。ついでに巻次やシリーズタイトルをそれぞれ取得できるようリファクタリングしました。
