### PR TITLE
Add publication_place support. cf. next-l/enju_leaf#295

### DIFF
--- a/lib/enju_ndl/ndl_search.rb
+++ b/lib/enju_ndl/ndl_search.rb
@@ -85,6 +85,7 @@ module EnjuNdl
         extent = get_extent(doc)
         publication_periodicity = doc.at('//dcndl:publicationPeriodicity').try(:content)
         statement_of_responsibility = doc.xpath('//dcndl:BibResource/dc:creator').map{|e| e.content}.join("; ")
+	publication_place = doc.at('//dcterms:publisher/foaf:Agent/dcndl:location').try(:content)
 
         manifestation = nil
         Agent.transaction do
@@ -106,7 +107,8 @@ module EnjuNdl
             :statement_of_responsibility => statement_of_responsibility,
             :start_page => extent[:start_page],
             :end_page => extent[:end_page],
-            :height => extent[:height]
+            :height => extent[:height],
+	    :publication_place => publication_place,
           )
           identifier = {}
           if isbn

--- a/spec/cassette_library/NdlBook/import/should_import_publication_place.yml
+++ b/spec/cassette_library/NdlBook/import/should_import_publication_place.yml
@@ -1,0 +1,239 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://iss.ndl.go.jp/api/sru?operation=searchRetrieve&recordSchema=dcndl&maximumRecords=1&query=%28itemno=R100000002-I000007725666-00%29&onlyBib=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - ! '*/*'
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: !binary |-
+        T0s=
+    headers:
+      !binary "ZGF0ZQ==":
+      - !binary |-
+        U2F0LCAxNiBBdWcgMjAxNCAwNzozNjowMiBHTVQ=
+      !binary "c2VydmVy":
+      - !binary |-
+        QXBhY2hl
+      !binary "ZXRhZw==":
+      - !binary |-
+        Ijc0ZDZmN2ZiMzQ2ZDBjN2Q4MmM4MTMxNjIwOWNjZGIxIg==
+      !binary "eC11YS1jb21wYXRpYmxl":
+      - !binary |-
+        SUU9RWRnZSxjaHJvbWU9MQ==
+      !binary "eC1ydW50aW1l":
+      - !binary |-
+        MC4yNzUyMTQ=
+      !binary "Y2FjaGUtY29udHJvbA==":
+      - !binary |-
+        bWF4LWFnZT0wLCBwcml2YXRlLCBtdXN0LXJldmFsaWRhdGU=
+      !binary "Y29udGVudC1sZW5ndGg=":
+      - !binary |-
+        NzUwMg==
+      !binary "c3RhdHVz":
+      - !binary |-
+        MjAw
+      !binary "Y29udGVudC10eXBl":
+      - !binary |-
+        YXBwbGljYXRpb24veG1sOyBjaGFyc2V0PXV0Zi04
+      !binary "c2V0LWNvb2tpZQ==":
+      - !binary |-
+        X2Zyb250X3Nlc3Npb25faWQ9ZjY5YzM2ZmVmNjRlYmFhODY3ZGM0OTA1ZDE1
+        MmI1NTA7IGRvbWFpbj0uaXNzLm5kbC5nby5qcDsgcGF0aD0vOyBleHBpcmVz
+        PVNhdCwgMTYtQXVnLTIwMTQgMDg6MzY6MDIgR01UOyBIdHRwT25seQ==
+      - !binary |-
+        c2VydmVyaWQ9MTEwNTsgcGF0aD0v
+      !binary "dmFyeQ==":
+      - !binary |-
+        QWNjZXB0LUVuY29kaW5nLFVzZXItQWdlbnQ=
+      !binary "eC1jb250ZW50LXR5cGUtb3B0aW9ucw==":
+      - !binary |-
+        bm9zbmlmZg==
+      !binary "eC1mcmFtZS1vcHRpb25z":
+      - !binary |-
+        U0FNRU9SSUdJTg==
+      !binary "Y29ubmVjdGlvbg==":
+      - !binary |-
+        Y2xvc2U=
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHNlYXJj
+        aFJldHJpZXZlUmVzcG9uc2UgeG1sbnM9Imh0dHA6Ly93d3cubG9jLmdvdi96
+        aW5nL3Nydy8iPgogIDx2ZXJzaW9uPjEuMjwvdmVyc2lvbj4KICA8bnVtYmVy
+        T2ZSZWNvcmRzPjE8L251bWJlck9mUmVjb3Jkcz4KICA8bmV4dFJlY29yZFBv
+        c2l0aW9uPjA8L25leHRSZWNvcmRQb3NpdGlvbj4KICA8ZXh0cmFSZXNwb25z
+        ZURhdGE+CiZsdDtmYWNldHMmZ3Q7CiAgJmx0O2xzdCBuYW1lPSZxdW90O1JF
+        UE9TSVRPUllfTk8mcXVvdDsmZ3Q7CiAgICAmbHQ7aW50IG5hbWU9JnF1b3Q7
+        UjEwMDAwMDAwMSZxdW90OyZndDsxJmx0Oy9pbnQmZ3Q7CiAgICAmbHQ7aW50
+        IG5hbWU9JnF1b3Q7UjEwMDAwMDAwMiZxdW90OyZndDsxJmx0Oy9pbnQmZ3Q7
+        CiAgJmx0Oy9sc3QmZ3Q7CiAgJmx0O2xzdCBuYW1lPSZxdW90O05EQyZxdW90
+        OyZndDsKICAgICZsdDtpbnQgbmFtZT0mcXVvdDszJnF1b3Q7Jmd0OzEmbHQ7
+        L2ludCZndDsKICAmbHQ7L2xzdCZndDsKICAmbHQ7bHN0IG5hbWU9JnF1b3Q7
+        SVNTVUVEX0RBVEUmcXVvdDsmZ3Q7CiAgICAmbHQ7aW50IG5hbWU9JnF1b3Q7
+        MjAwNSZxdW90OyZndDsxJmx0Oy9pbnQmZ3Q7CiAgJmx0Oy9sc3QmZ3Q7CiAg
+        Jmx0O2xzdCBuYW1lPSZxdW90O0xJQlJBUlkmcXVvdDsmZ3Q7CiAgICAmbHQ7
+        aW50IG5hbWU9JnF1b3Q744GV44GE44Gf44G+5biC56uL5Lit5aSu5Zuz5pu4
+        6aSoJnF1b3Q7Jmd0OzEmbHQ7L2ludCZndDsKICAgICZsdDtpbnQgbmFtZT0m
+        cXVvdDvkuqzpg73lupznq4vnt4/lkIjos4fmlpnppKgmcXVvdDsmZ3Q7MSZs
+        dDsvaW50Jmd0OwogICAgJmx0O2ludCBuYW1lPSZxdW90O+S9kOizgOecjOer
+        i+Wbs+abuOmkqCZxdW90OyZndDsxJmx0Oy9pbnQmZ3Q7CiAgICAmbHQ7aW50
+        IG5hbWU9JnF1b3Q75Y2D6JGJ5biC5Lit5aSu5Zuz5pu46aSoJnF1b3Q7Jmd0
+        OzEmbHQ7L2ludCZndDsKICAgICZsdDtpbnQgbmFtZT0mcXVvdDvljYPokYnn
+        nIznq4vkuK3lpK7lm7Pmm7jppKgmcXVvdDsmZ3Q7MSZsdDsvaW50Jmd0Owog
+        ICAgJmx0O2ludCBuYW1lPSZxdW90O+WNg+iRieecjOeri+adsemDqOWbs+ab
+        uOmkqCZxdW90OyZndDsxJmx0Oy9pbnQmZ3Q7CiAgICAmbHQ7aW50IG5hbWU9
+        JnF1b3Q75ZKM5q2M5bGx55yM56uL5Zuz5pu46aSoJnF1b3Q7Jmd0OzEmbHQ7
+        L2ludCZndDsKICAgICZsdDtpbnQgbmFtZT0mcXVvdDvlm73nq4vlm73kvJrl
+        m7Pmm7jppKgmcXVvdDsmZ3Q7MSZsdDsvaW50Jmd0OwogICAgJmx0O2ludCBu
+        YW1lPSZxdW90O+WfvOeOieecjOeri+a1puWSjOWbs+abuOmkqCZxdW90OyZn
+        dDsxJmx0Oy9pbnQmZ3Q7CiAgICAmbHQ7aW50IG5hbWU9JnF1b3Q75aSn5YiG
+        55yM56uL5Zuz5pu46aSoJnF1b3Q7Jmd0OzEmbHQ7L2ludCZndDsKICAgICZs
+        dDtpbnQgbmFtZT0mcXVvdDvlpKfpmKrlupznq4vkuK3lpK7lm7Pmm7jppKgm
+        cXVvdDsmZ3Q7MSZsdDsvaW50Jmd0OwogICAgJmx0O2ludCBuYW1lPSZxdW90
+        O+WuruW0juecjOeri+Wbs+abuOmkqCZxdW90OyZndDsxJmx0Oy9pbnQmZ3Q7
+        CiAgICAmbHQ7aW50IG5hbWU9JnF1b3Q75a+M5bGx55yM56uL5Zuz5pu46aSo
+        JnF1b3Q7Jmd0OzEmbHQ7L2ludCZndDsKICAgICZsdDtpbnQgbmFtZT0mcXVv
+        dDvlsbHlj6PnnIznq4vlsbHlj6Plm7Pmm7jppKgmcXVvdDsmZ3Q7MSZsdDsv
+        aW50Jmd0OwogICAgJmx0O2ludCBuYW1lPSZxdW90O+WxseaiqOecjOeri+Wb
+        s+abuOmkqCZxdW90OyZndDsxJmx0Oy9pbnQmZ3Q7CiAgICAmbHQ7aW50IG5h
+        bWU9JnF1b3Q75bKQ6Zic55yM5Zuz5pu46aSoJnF1b3Q7Jmd0OzEmbHQ7L2lu
+        dCZndDsKICAgICZsdDtpbnQgbmFtZT0mcXVvdDvluoPls7bnnIznq4vlm7Pm
+        m7jppKgmcXVvdDsmZ3Q7MSZsdDsvaW50Jmd0OwogICAgJmx0O2ludCBuYW1l
+        PSZxdW90O+W+s+WztuecjOeri+Wbs+abuOmkqCZxdW90OyZndDsxJmx0Oy9p
+        bnQmZ3Q7CiAgICAmbHQ7aW50IG5hbWU9JnF1b3Q75pyt5bmM5biC5Lit5aSu
+        5Zuz5pu46aSoJnF1b3Q7Jmd0OzEmbHQ7L2ludCZndDsKICAgICZsdDtpbnQg
+        bmFtZT0mcXVvdDvmnbHkuqzpg73nq4vkuK3lpK7lm7Pmm7jppKgmcXVvdDsm
+        Z3Q7MSZsdDsvaW50Jmd0OwogICAgJmx0O2ludCBuYW1lPSZxdW90O+agg+ac
+        qOecjOeri+Wbs+abuOmkqCZxdW90OyZndDsxJmx0Oy9pbnQmZ3Q7CiAgICAm
+        bHQ7aW50IG5hbWU9JnF1b3Q75qiq5rWc5biC5Lit5aSu5Zuz5pu46aSoJnF1
+        b3Q7Jmd0OzEmbHQ7L2ludCZndDsKICAgICZsdDtpbnQgbmFtZT0mcXVvdDvm
+        spbnuITnnIznq4vlm7Pmm7jppKgmcXVvdDsmZ3Q7MSZsdDsvaW50Jmd0Owog
+        ICAgJmx0O2ludCBuYW1lPSZxdW90O+eGiuacrOecjOeri+Wbs+abuOmkqCZx
+        dW90OyZndDsxJmx0Oy9pbnQmZ3Q7CiAgICAmbHQ7aW50IG5hbWU9JnF1b3Q7
+        55yM56uL6ZW36YeO5Zuz5pu46aSoJnF1b3Q7Jmd0OzEmbHQ7L2ludCZndDsK
+        ICAgICZsdDtpbnQgbmFtZT0mcXVvdDvnpo/kupXnnIznq4vlm7Pmm7jppKgm
+        cXVvdDsmZ3Q7MSZsdDsvaW50Jmd0OwogICAgJmx0O2ludCBuYW1lPSZxdW90
+        O+emj+WyoeecjOeri+Wbs+abuOmkqCZxdW90OyZndDsxJmx0Oy9pbnQmZ3Q7
+        CiAgICAmbHQ7aW50IG5hbWU9JnF1b3Q756aP5bO255yM56uL5Zuz5pu46aSo
+        JnF1b3Q7Jmd0OzEmbHQ7L2ludCZndDsKICAgICZsdDtpbnQgbmFtZT0mcXVv
+        dDvnp4vnlLDnnIznq4vlm7Pmm7jppKgmcXVvdDsmZ3Q7MSZsdDsvaW50Jmd0
+        OwogICAgJmx0O2ludCBuYW1lPSZxdW90O+e+pOmmrOecjOeri+Wbs+abuOmk
+        qCZxdW90OyZndDsxJmx0Oy9pbnQmZ3Q7CiAgICAmbHQ7aW50IG5hbWU9JnF1
+        b3Q76ZW35bSO55yM56uL6ZW35bSO5Zuz5pu46aSoJnF1b3Q7Jmd0OzEmbHQ7
+        L2ludCZndDsKICAgICZsdDtpbnQgbmFtZT0mcXVvdDvpnZnlsqHluILnq4vk
+        uK3lpK7lm7Pmm7jppKgmcXVvdDsmZ3Q7MSZsdDsvaW50Jmd0OwogICAgJmx0
+        O2ludCBuYW1lPSZxdW90O+mdmeWyoeecjOeri+S4reWkruWbs+abuOmkqCZx
+        dW90OyZndDsxJmx0Oy9pbnQmZ3Q7CiAgICAmbHQ7aW50IG5hbWU9JnF1b3Q7
+        6aaZ5bed55yM56uL5Zuz5pu46aSoJnF1b3Q7Jmd0OzEmbHQ7L2ludCZndDsK
+        ICAmbHQ7L2xzdCZndDsKJmx0Oy9mYWNldHMmZ3Q7CiAgPC9leHRyYVJlc3Bv
+        bnNlRGF0YT4KICA8cmVjb3Jkcz4KICAgIDxyZWNvcmQ+CiAgICAgIDxyZWNv
+        cmRTY2hlbWE+aW5mbzpzcncvc2NoZW1hLzEvZGMtdjEuMTwvcmVjb3JkU2No
+        ZW1hPgogICAgICA8cmVjb3JkUGFja2luZz5zdHJpbmc8L3JlY29yZFBhY2tp
+        bmc+CiAgICAgIDxyZWNvcmREYXRhPgombHQ7cmRmOlJERiB4bWxuczpkY3Rl
+        cm1zPSZxdW90O2h0dHA6Ly9wdXJsLm9yZy9kYy90ZXJtcy8mcXVvdDsgeG1s
+        bnM6cmRmPSZxdW90O2h0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRm
+        LXN5bnRheC1ucyMmcXVvdDsgeG1sbnM6ZGNuZGw9JnF1b3Q7aHR0cDovL25k
+        bC5nby5qcC9kY25kbC90ZXJtcy8mcXVvdDsgeG1sbnM6Zm9hZj0mcXVvdDto
+        dHRwOi8veG1sbnMuY29tL2ZvYWYvMC4xLyZxdW90OyB4bWxuczpyZGZzPSZx
+        dW90O2h0dHA6Ly93d3cudzMub3JnLzIwMDAvMDEvcmRmLXNjaGVtYSMmcXVv
+        dDsgeG1sbnM6ZGM9JnF1b3Q7aHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRz
+        LzEuMS8mcXVvdDsgeG1sbnM6b3dsPSZxdW90O2h0dHA6Ly93d3cudzMub3Jn
+        LzIwMDIvMDcvb3dsIyZxdW90OyZndDsKICAmbHQ7ZGNuZGw6QmliQWRtaW5S
+        ZXNvdXJjZSByZGY6YWJvdXQ9JnF1b3Q7aHR0cDovL2lzcy5uZGwuZ28uanAv
+        Ym9va3MvUjEwMDAwMDAwMi1JMDAwMDA3NzI1NjY2LTAwJnF1b3Q7Jmd0Owog
+        ICAgJmx0O2RjbmRsOmNhdGFsb2dpbmdTdGF0dXMmZ3Q7QzcmbHQ7L2RjbmRs
+        OmNhdGFsb2dpbmdTdGF0dXMmZ3Q7CiAgICAmbHQ7ZGNuZGw6YmliUmVjb3Jk
+        Q2F0ZWdvcnkmZ3Q7UjEwMDAwMDAwMiZsdDsvZGNuZGw6YmliUmVjb3JkQ2F0
+        ZWdvcnkmZ3Q7CiAgICAmbHQ7ZGNuZGw6cmVjb3JkIHJkZjpyZXNvdXJjZT0m
+        cXVvdDtodHRwOi8vaXNzLm5kbC5nby5qcC9ib29rcy9SMTAwMDAwMDAyLUkw
+        MDAwMDc3MjU2NjYtMDAjbWF0ZXJpYWwmcXVvdDsvJmd0OwogICZsdDsvZGNu
+        ZGw6QmliQWRtaW5SZXNvdXJjZSZndDsKICAmbHQ7ZGNuZGw6QmliUmVzb3Vy
+        Y2UgcmRmOmFib3V0PSZxdW90O2h0dHA6Ly9pc3MubmRsLmdvLmpwL2Jvb2tz
+        L1IxMDAwMDAwMDItSTAwMDAwNzcyNTY2Ni0wMCNtYXRlcmlhbCZxdW90OyZn
+        dDsKICAgICZsdDtkY3Rlcm1zOmlkZW50aWZpZXIgcmRmOmRhdGF0eXBlPSZx
+        dW90O2h0dHA6Ly9uZGwuZ28uanAvZGNuZGwvdGVybXMvSlBOTyZxdW90OyZn
+        dDsyMDc4MzI1MiZsdDsvZGN0ZXJtczppZGVudGlmaWVyJmd0OwogICAgJmx0
+        O2RjdGVybXM6aWRlbnRpZmllciByZGY6ZGF0YXR5cGU9JnF1b3Q7aHR0cDov
+        L25kbC5nby5qcC9kY25kbC90ZXJtcy9JU0JOJnF1b3Q7Jmd0OzQtOTI1MTU2
+        LTEwLTEmbHQ7L2RjdGVybXM6aWRlbnRpZmllciZndDsKICAgICZsdDtyZGZz
+        OnNlZUFsc28gcmRmOnJlc291cmNlPSZxdW90O2h0dHA6Ly9pZC5uZGwuZ28u
+        anAvanBuby8yMDc4MzI1MiZxdW90Oy8mZ3Q7CiAgICAmbHQ7cmRmczpzZWVB
+        bHNvIHJkZjpyZXNvdXJjZT0mcXVvdDtodHRwOi8vaXNzLm5kbC5nby5qcC9p
+        c2JuLzQ5MjUxNTYxMDEmcXVvdDsvJmd0OwogICAgJmx0O2RjdGVybXM6dGl0
+        bGUmZ3Q75Zuz5pu46aSo5oOF5aCx5aSn5a2m5Y+yIDogMjXlubTjga7oqJjp
+        jLImbHQ7L2RjdGVybXM6dGl0bGUmZ3Q7CiAgICAmbHQ7ZGM6dGl0bGUmZ3Q7
+        CiAgICAgICZsdDtyZGY6RGVzY3JpcHRpb24mZ3Q7CiAgICAgICAgJmx0O3Jk
+        Zjp2YWx1ZSZndDvlm7Pmm7jppKjmg4XloLHlpKflrablj7IgOiAyNeW5tOOB
+        ruiomOmMsiZsdDsvcmRmOnZhbHVlJmd0OwogICAgICAgICZsdDtkY25kbDp0
+        cmFuc2NyaXB0aW9uJmd0O+ODiOOCt+ODp+OCq+ODsyDjgrjjg6fjgqbjg5vj
+        gqYg44OA44Kk44Ks44Kv44K3IDogMjXjg43jg7Mg44OOIOOCreODreOCryZs
+        dDsvZGNuZGw6dHJhbnNjcmlwdGlvbiZndDsKICAgICAgJmx0Oy9yZGY6RGVz
+        Y3JpcHRpb24mZ3Q7CiAgICAmbHQ7L2RjOnRpdGxlJmd0OwogICAgJmx0O2Rj
+        dGVybXM6Y3JlYXRvciZndDsKICAgICAgJmx0O2ZvYWY6QWdlbnQgcmRmOmFi
+        b3V0PSZxdW90O2h0dHA6Ly9pZC5uZGwuZ28uanAvYXV0aC9lbnRpdHkvMDA5
+        Njg5MTcmcXVvdDsmZ3Q7CiAgICAgICAgJmx0O2ZvYWY6bmFtZSZndDvnrZHm
+        s6LlpKflrablpKflrabpmaLlm7Pmm7jppKjmg4XloLHjg6Hjg4fjgqPjgqLn
+        oJTnqbbnp5EmbHQ7L2ZvYWY6bmFtZSZndDsKICAgICAgJmx0Oy9mb2FmOkFn
+        ZW50Jmd0OwogICAgJmx0Oy9kY3Rlcm1zOmNyZWF0b3ImZ3Q7CiAgICAmbHQ7
+        ZGM6Y3JlYXRvciZndDvnrZHms6LlpKflrablpKflrabpmaLlm7Pmm7jppKjm
+        g4XloLHjg6Hjg4fjgqPjgqLnoJTnqbbnp5Eg57eoJmx0Oy9kYzpjcmVhdG9y
+        Jmd0OwogICAgJmx0O2RjdGVybXM6cHVibGlzaGVyJmd0OwogICAgICAmbHQ7
+        Zm9hZjpBZ2VudCZndDsKICAgICAgICAmbHQ7Zm9hZjpuYW1lJmd0O+etkeaz
+        ouWkp+WtpuWkp+WtpumZouWbs+abuOmkqOaDheWgseODoeODh+OCo+OCoueg
+        lOeptuenkSZsdDsvZm9hZjpuYW1lJmd0OwogICAgICAgICZsdDtkY25kbDp0
+        cmFuc2NyaXB0aW9uJmd0O+ODhOOCr+ODkCDjg4DjgqTjgqzjgq8g44OA44Kk
+        44Ks44Kv44Kk44OzIOODiOOCt+ODp+OCq+ODsyDjgrjjg6fjgqbjg5vjgqYg
+        44Oh44OH44Kj44KiIOOCseODs+OCreODpeOCpuOCqyZsdDsvZGNuZGw6dHJh
+        bnNjcmlwdGlvbiZndDsKICAgICAgICAmbHQ7ZGNuZGw6bG9jYXRpb24mZ3Q7
+        44Gk44GP44GwJmx0Oy9kY25kbDpsb2NhdGlvbiZndDsKICAgICAgJmx0Oy9m
+        b2FmOkFnZW50Jmd0OwogICAgJmx0Oy9kY3Rlcm1zOnB1Ymxpc2hlciZndDsK
+        ICAgICZsdDtkY25kbDpwdWJsaWNhdGlvblBsYWNlIHJkZjpkYXRhdHlwZT0m
+        cXVvdDtodHRwOi8vcHVybC5vcmcvZGMvdGVybXMvSVNPMzE2NiZxdW90OyZn
+        dDtKUCZsdDsvZGNuZGw6cHVibGljYXRpb25QbGFjZSZndDsKICAgICZsdDtk
+        Y3Rlcm1zOmRhdGUmZ3Q7MjAwNS4zJmx0Oy9kY3Rlcm1zOmRhdGUmZ3Q7CiAg
+        ICAmbHQ7ZGN0ZXJtczppc3N1ZWQgcmRmOmRhdGF0eXBlPSZxdW90O2h0dHA6
+        Ly9wdXJsLm9yZy9kYy90ZXJtcy9XM0NEVEYmcXVvdDsmZ3Q7MjAwNSZsdDsv
+        ZGN0ZXJtczppc3N1ZWQmZ3Q7CiAgICAmbHQ7ZGN0ZXJtczpzdWJqZWN0Jmd0
+        OwogICAgICAmbHQ7cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0mcXVvdDto
+        dHRwOi8vaWQubmRsLmdvLmpwL2F1dGgvZW50aXR5LzAwMzA2ODM2JnF1b3Q7
+        Jmd0OwogICAgICAgICZsdDtyZGY6dmFsdWUmZ3Q75Zuz5pu46aSo5oOF5aCx
+        5aSn5a2mJmx0Oy9yZGY6dmFsdWUmZ3Q7CiAgICAgICZsdDsvcmRmOkRlc2Ny
+        aXB0aW9uJmd0OwogICAgJmx0Oy9kY3Rlcm1zOnN1YmplY3QmZ3Q7CiAgICAm
+        bHQ7ZGN0ZXJtczpzdWJqZWN0IHJkZjpyZXNvdXJjZT0mcXVvdDtodHRwOi8v
+        aWQubmRsLmdvLmpwL2NsYXNzL25kbGMvRkIyMiZxdW90Oy8mZ3Q7CiAgICAm
+        bHQ7ZGN0ZXJtczpzdWJqZWN0IHJkZjpyZXNvdXJjZT0mcXVvdDtodHRwOi8v
+        aWQubmRsLmdvLmpwL2NsYXNzL25kYzkvMzc3LjI4JnF1b3Q7LyZndDsKICAg
+        ICZsdDtkY3Rlcm1zOmxhbmd1YWdlIHJkZjpkYXRhdHlwZT0mcXVvdDtodHRw
+        Oi8vcHVybC5vcmcvZGMvdGVybXMvSVNPNjM5LTImcXVvdDsmZ3Q7anBuJmx0
+        Oy9kY3Rlcm1zOmxhbmd1YWdlJmd0OwogICAgJmx0O2RjdGVybXM6ZXh0ZW50
+        Jmd0OzM3MnAg5Zuz54mIMTRwIDsgMjdjbSZsdDsvZGN0ZXJtczpleHRlbnQm
+        Z3Q7CiAgICAmbHQ7ZGNuZGw6cHJpY2UmZ3Q76Z2e5aOy5ZOBJmx0Oy9kY25k
+        bDpwcmljZSZndDsKICAgICZsdDtkY3Rlcm1zOmF1ZGllbmNlJmd0O+S4gOiI
+        rCZsdDsvZGN0ZXJtczphdWRpZW5jZSZndDsKICAgICZsdDtkY25kbDptYXRl
+        cmlhbFR5cGUgcmRmOnJlc291cmNlPSZxdW90O2h0dHA6Ly9uZGwuZ28uanAv
+        bmRsdHlwZS9Cb29rJnF1b3Q7IHJkZnM6bGFiZWw9JnF1b3Q75Zuz5pu4JnF1
+        b3Q7LyZndDsKICAgICZsdDtkY25kbDptYXRlcmlhbFR5cGUgcmRmOnJlc291
+        cmNlPSZxdW90O2h0dHA6Ly9uZGwuZ28uanAvbmRsdHlwZS9Hb3Zlcm5tZW50
+        UHVibGljYXRpb24mcXVvdDsgcmRmczpsYWJlbD0mcXVvdDvmlL/lupzliIro
+        oYzniakmcXVvdDsvJmd0OwogICAgJmx0O2RjbmRsOm1hdGVyaWFsVHlwZSBy
+        ZGY6cmVzb3VyY2U9JnF1b3Q7aHR0cDovL25kbC5nby5qcC9uZGx0eXBlL05h
+        dGlvbmFsUHVibGljYXRpb24mcXVvdDsgcmRmczpsYWJlbD0mcXVvdDvlrpjl
+        hazluoHliIrooYzniakmcXVvdDsvJmd0OwogICAgJmx0O2RjdGVybXM6YWNj
+        ZXNzUmlnaHRzJmd0O1MwMVA5OVU5OSZsdDsvZGN0ZXJtczphY2Nlc3NSaWdo
+        dHMmZ3Q7CiAgJmx0Oy9kY25kbDpCaWJSZXNvdXJjZSZndDsKJmx0Oy9yZGY6
+        UkRGJmd0OwogICAgICA8L3JlY29yZERhdGE+CiAgICAgIDxyZWNvcmRQb3Np
+        dGlvbj4xPC9yZWNvcmRQb3NpdGlvbj4KICAgIDwvcmVjb3JkPgogIDwvcmVj
+        b3Jkcz4KPC9zZWFyY2hSZXRyaWV2ZVJlc3BvbnNlPgo=
+    http_version: !binary |-
+      MS4w
+  recorded_at: Sat, 16 Aug 2014 01:00:55 GMT
+recorded_with: VCR 2.9.2

--- a/spec/models/ndl_book_spec.rb
+++ b/spec/models/ndl_book_spec.rb
@@ -116,5 +116,10 @@ describe NdlBook do
       book = NdlBook.search("4788509105")[:items].first
       book.series_title.should eq ""
     end
+
+    it "should import publication_place", :vcr => true do
+      manifestation = NdlBook.import_from_sru_response('R100000002-I000007725666-00')
+      manifestation.publication_place.should eq "つくば"
+    end
   end
 end


### PR DESCRIPTION
next-l/enju_leaf#295 での出版地の追加に対応する分です。

publicationPlaceには国名コードしか入っていないようなので、foaf:Agent/dcndl:locationから取得しています。
